### PR TITLE
improvement: CSS only page loader

### DIFF
--- a/src/components/base/Loader/Loader.styles.ts
+++ b/src/components/base/Loader/Loader.styles.ts
@@ -14,14 +14,22 @@ export const Container = styled.div`
   opacity: 1;
   overflow: hidden;
   background-color: ${vars.theme((theme) => theme.body.back)};
+  animation: 1.2s linear 0.2s 1 normal forwards running fade;
 
-  &.removing {
-    opacity: 0;
-    transition: opacity 1.2s;
-  }
-
-  &.done {
-    display: none;
+  @keyframes fade {
+    0% {
+      z-index: 1000;
+      opacity: 1;
+      visibility: visible;
+    }
+    98% {
+      opacity: 0;
+    }
+    100% {
+      z-index: 0;
+      opacity: 0;
+      visibility: hidden;
+    }
   }
 `
 

--- a/src/components/base/Loader/Loader.tsx
+++ b/src/components/base/Loader/Loader.tsx
@@ -1,26 +1,8 @@
-import { useEffect, useState } from 'react'
 import * as S from './Loader.styles'
 
 export const Loader = () => {
-  const [currentState, setCurrentState] = useState('')
-
-  const markAsDone = () => {
-    setCurrentState('removing')
-    setTimeout(() => setCurrentState('done'), 1000)
-  }
-
-  useEffect(() => {
-    if (document.readyState === 'complete') {
-      markAsDone()
-    } else {
-      window.addEventListener('DOMContentLoaded', markAsDone)
-
-      return () => window.removeEventListener('DOMContentLoaded', markAsDone)
-    }
-  }, [])
-
   return (
-    <S.Container className={currentState}>
+    <S.Container>
       <S.Spinner />
     </S.Container>
   )


### PR DESCRIPTION
Makes the loader's animation css-only to prevent the screen not fading on startup (unfortunatelly nextjs doesn't run useEffect on every request).